### PR TITLE
overlays: Add brightness slider styles [3/3]

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -385,6 +385,21 @@ PRODUCT_PACKAGES += \
     VolumeShadedLayer \
     VolumeAOSPRevamped
 
+# Brightness slider styles
+PRODUCT_PACKAGES += \
+    BrightnessSliderAcunOverlay \
+    BrightnessSliderBangOverlay \
+    BrightnessSliderCyberpunkOverlay \
+    BrightnessSliderFilledOverlay \
+    BrightnessSliderGradientRoundedBarOverlay \
+    BrightnessSliderLeafyOutlineOverlay \
+    BrightnessSliderMinimalThumbOverlay \
+    BrightnessSliderOutlineOverlay \
+    BrightnessSliderRoundedClipOverlay \
+    BrightnessSliderShadedOverlay \
+    BrightnessSliderThinOverlay \
+    BrightnessSliderTranslucentOverlay
+
 # Include {Lato,Rubik} fonts
 $(call inherit-product-if-exists, external/google-fonts/lato/fonts.mk)
 $(call inherit-product-if-exists, external/google-fonts/rubik/fonts.mk)

--- a/themes/brightness_slider/BrightnessSliderAcun/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderAcun/Android.bp
@@ -1,0 +1,10 @@
+//
+// Copyright (C) 2023 The Leaf Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+runtime_resource_overlay {
+    name: "BrightnessSliderAcunOverlay",
+    theme: "BrightnessSliderAcun",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderAcun/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderAcun/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.acun"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Acun"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderAcun/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderAcun/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center"
+          android:id="@android:id/progress">
+        <scale android:scaleWidth="100%">
+            <selector>
+                <item android:state_pressed="true">
+                    <inset android:insetLeft="0.0dip"
+                           android:insetRight="0.0dip">
+                        <shape android:tint="?android:colorAccent"
+                               android:shape="rectangle">
+                            <size android:height="48.0dip" />
+                            <stroke android:width="12dp"
+                                    android:color="#A5FFFFFF" />
+                            <solid android:color="#ffffffff" />
+                            <corners android:radius="35.0dip" />
+                        </shape>
+                    </inset >
+                </item>
+                <item android:state_pressed="false">
+                    <inset android:insetLeft="0.0dip"
+                           android:insetRight="0.0dip">
+                        <shape android:tint="?android:colorAccent"
+                               android:shape="rectangle">
+                            <size android:height="48.0dip" />
+                            <stroke android:width="12dp"
+                                    android:color="#A5FFFFFF" />
+                            <solid android:color="#ffffffff" />
+                            <corners android:radius="35.0dip" />
+                        </shape>
+                    </inset >
+                </item>
+            </selector>
+        </scale>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderBang/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderBang/Android.bp
@@ -1,0 +1,10 @@
+//
+// Copyright (C) 2023 The Leaf Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+runtime_resource_overlay {
+    name: "BrightnessSliderBangOverlay",
+    theme: "BrightnessSliderBang",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderBang/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderBang/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.bang"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Bang"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderBang/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderBang/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center"
+          android:id="@android:id/background">
+        <selector>
+            <item android:state_pressed="true">
+                <shape android:tint="?android:colorAccent"
+                       android:shape="rectangle">
+                    <size android:height="35.0dip" />
+                    <solid android:color="#2c626161" />
+                    <corners android:bottomLeftRadius="5dp"
+                             android:bottomRightRadius="60dp"
+                             android:topLeftRadius="60dp"
+                             android:topRightRadius="5dp" />
+                </shape>
+            </item>
+            <item android:state_pressed="false">
+                <shape android:tint="?android:colorAccent"
+                       android:shape="rectangle">
+                    <size android:height="35.0dip" />
+                    <solid android:color="#2c626161" />
+                    <corners android:bottomLeftRadius="5dp"
+                             android:bottomRightRadius="60dp"
+                             android:topLeftRadius="60dp"
+                             android:topRightRadius="5dp" />
+                </shape>
+            </item>
+        </selector>
+    </item>
+    <item android:gravity="fill_horizontal|center"
+          android:id="@android:id/progress">
+        <scale android:scaleWidth="100%">
+            <selector>
+                <item android:state_pressed="true">
+                    <inset android:insetLeft="0.0dip"
+                           android:insetRight="0.0dip">
+                        <shape android:tint="?android:colorAccent"
+                               android:shape="rectangle">
+                            <size android:height="35.0dip" />
+                            <solid android:color="#ffffffff" />
+                            <corners android:bottomLeftRadius="5dp"
+                                     android:bottomRightRadius="60dp"
+                                     android:topLeftRadius="60dp"
+                                     android:topRightRadius="5dp" />
+                        </shape>
+                    </inset >
+                </item>
+                <item android:state_pressed="false">
+                    <inset android:insetLeft="0.0dip"
+                           android:insetRight="0.0dip">
+                        <shape android:tint="?android:colorAccent"
+                               android:shape="rectangle">
+                            <size android:height="35.0dip" />
+                            <solid android:color="@android:color/white" />
+                            <corners android:bottomLeftRadius="5dp"
+                                     android:bottomRightRadius="60dp"
+                                     android:topLeftRadius="60dp"
+                                     android:topRightRadius="5dp" />
+                        </shape>
+                    </inset >
+                </item>
+            </selector>
+        </scale>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderCyberPunk/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderCyberPunk/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "BrightnessSliderCyberpunkOverlay",
+    theme: "BrightnessSliderCyberpunk",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderCyberPunk/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderCyberPunk/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.cyberpunk"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="CyberPunk"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="6.0dip" />
+            <size android:height="12.0dip" />
+            <solid android:color="@*android:color/system_neutral2_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable-night/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable-night/brightness_progress_full_drawable.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="6.0dip" />
+            <size android:height="12.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item android:gravity="end|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="12.0dip" />
+            <size
+                android:height="24.0dip"
+                android:width="12.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:gravity="end|center"
+        android:end="5.0dip">
+        <shape android:shape="rectangle">
+            <corners android:radius="7.0dip" />
+            <size
+                android:height="14.0dip"
+                android:width="2.0dip" />
+            <solid android:color="@*android:color/system_neutral2_800" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="6.0dip" />
+            <size android:height="12.0dip" />
+            <solid android:color="@*android:color/system_neutral1_200" />
+        </shape>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderCyberPunk/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="6.0dip" />
+            <size android:height="12.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item android:gravity="end|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="12.0dip" />
+            <size
+                android:height="24.0dip"
+                android:width="12.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:gravity="end|center"
+        android:end="5.0dip">
+        <shape android:shape="rectangle">
+            <corners android:radius="7.0dip" />
+            <size
+                android:height="14.0dip"
+                android:width="2.0dip" />
+            <solid android:color="@*android:color/system_neutral2_0" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderFilled/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderFilled/Android.bp
@@ -1,0 +1,10 @@
+//
+// Copyright (C) 2023 The Leaf Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+runtime_resource_overlay {
+    name: "BrightnessSliderFilledOverlay",
+    theme: "BrightnessSliderFilled",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderFilled/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderFilled/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.filled"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Filled"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderFilled/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderFilled/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background" android:gravity="center_vertical|fill_horizontal">
+        <shape>
+            <size android:height="30.0dip" />
+            <corners android:radius="30.0dip" />
+            <solid android:color="@android:color/system_neutral1_800" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress" android:gravity="center_vertical|fill_horizontal">
+        <scale android:scaleWidth="100%">
+            <shape>
+                <size android:height="30.0dip" />
+                <solid android:color="?android:colorAccent" />
+                <corners android:radius="30.0dip" />
+            </shape>
+        </scale>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderFilled/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderFilled/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background" android:gravity="center_vertical|fill_horizontal">
+        <shape>
+            <size android:height="30.0dip" />
+            <corners android:radius="30.0dip" />
+            <solid android:color="@android:color/system_neutral1_50" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress" android:gravity="center_vertical|fill_horizontal">
+        <scale android:scaleWidth="100%">
+            <shape>
+                <size android:height="30.0dip" />
+                <solid android:color="?android:colorAccent" />
+                <corners android:radius="30.0dip" />
+            </shape>
+        </scale>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/Android.bp
@@ -1,0 +1,10 @@
+//
+// Copyright (C) 2023 The Leaf Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+runtime_resource_overlay {
+    name: "BrightnessSliderGradientRoundedBarOverlay",
+    theme: "BrightnessSliderGradientRoundedBar",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.gradientroundedbar"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="GradientRoundedBar"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable-night/brightness_bg.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable-night/brightness_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="24.0dip" />
+    <gradient android:startColor="@android:color/system_accent1_100" android:endColor="@android:color/system_accent3_100" android:angle="0.0" />
+    <size android:height="48.0dip" android:width="48.0dip" />
+</shape>
+

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center" android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="28.0dip" />
+            <size android:height="48.0dip" />
+            <solid android:color="@android:color/system_neutral1_800" />
+        </shape>
+    </item>
+    <item android:gravity="fill_horizontal|center" android:id="@android:id/progress">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>
+

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable-night/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable-night/brightness_progress_full_drawable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="28.0dip" />
+            <size android:height="48.0dip" />
+            <gradient
+                android:angle="0.0"
+                android:startColor="@android:color/system_accent1_100"
+                android:endColor="@android:color/system_accent3_100" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable/brightness_bg.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable/brightness_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="24.0dip" />
+    <gradient android:startColor="@android:color/system_accent1_600" android:endColor="@android:color/system_accent3_600" android:angle="0.0" />
+    <size android:height="48.0dip" android:width="48.0dip" />
+</shape>
+

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center" android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="28.0dip" />
+            <size android:height="48.0dip" />
+            <solid android:color="@*android:color/surface_light" />
+        </shape>
+    </item>
+    <item android:gravity="fill_horizontal|center" android:id="@android:id/progress">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>
+

--- a/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderGradientRoundedBar/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="28.0dip" />
+            <size android:height="48.0dip" />
+            <gradient
+                android:angle="0.0"
+                android:startColor="@android:color/system_accent1_600"
+                android:endColor="@android:color/system_accent3_600" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "BrightnessSliderLeafyOutlineOverlay",
+    theme: "BrightnessSliderLeafyOutline",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.leafyoutline"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="LeafyOutline"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable-night/brightness_mirror_background.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable-night/brightness_mirror_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?android:colorBackgroundFloating" />
+    <corners
+        android:bottomLeftRadius="14.0dp"
+        android:bottomRightRadius="28.0dip"
+        android:topLeftRadius="28.0dip"
+        android:topRightRadius="14.0dp" />
+</shape>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <layer-list>
+            <item android:gravity="fill_horizontal|center">
+                <shape android:shape="rectangle">
+                    <corners
+                        android:bottomLeftRadius="10.0dp"
+                        android:bottomRightRadius="32.0dp"
+                        android:topLeftRadius="32.0dp"
+                        android:topRightRadius="10.0dp" />
+                    <size android:height="48.0dip" />
+                    <solid android:color="#1AFFFFFF" />
+                </shape>
+            </item>
+            <item
+                android:end="4.5dip"
+                android:gravity="fill_horizontal|center"
+                android:start="4.5dip">
+                <shape android:shape="rectangle">
+                    <corners
+                        android:bottomLeftRadius="6.0dp"
+                        android:bottomRightRadius="28.0dp"
+                        android:topLeftRadius="28.0dp"
+                        android:topRightRadius="6.0dp" />
+                    <size android:height="40.0dip" />
+                    <solid android:color="?android:colorBackgroundFloating" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_bg.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_bg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center">
+        <shape>
+            <corners android:topLeftRadius="32.0dip" android:topRightRadius="10.0dip" android:bottomLeftRadius="10.0dip" android:bottomRightRadius="32.0dip" />
+            <solid android:color="?android:colorAccent" />
+            <size android:height="48.0dip" android:width="48.0dip" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_mirror_background.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_mirror_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?android:colorBackgroundFloating" />
+    <corners
+        android:bottomLeftRadius="14.0dp"
+        android:bottomRightRadius="28.0dip"
+        android:topLeftRadius="28.0dip"
+        android:topRightRadius="14.0dp" />
+</shape>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <layer-list>
+            <item android:gravity="fill_horizontal|center">
+                <shape android:shape="rectangle">
+                    <corners
+                        android:bottomLeftRadius="10.0dp"
+                        android:bottomRightRadius="32.0dp"
+                        android:topLeftRadius="32.0dp"
+                        android:topRightRadius="10.0dp" />
+                    <size android:height="48.0dip" />
+                    <solid android:color="#1A000000" />
+                </shape>
+            </item>
+            <item
+                android:end="4.5dip"
+                android:gravity="fill_horizontal|center"
+                android:start="4.5dip">
+                <shape android:shape="rectangle">
+                    <corners
+                        android:bottomLeftRadius="6.0dp"
+                        android:bottomRightRadius="28.0dp"
+                        android:topLeftRadius="28.0dp"
+                        android:topRightRadius="6.0dp" />
+                    <size android:height="40.0dip" />
+                    <solid android:color="?android:colorBackgroundFloating" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners
+                android:bottomLeftRadius="10.0dp"
+                android:bottomRightRadius="32.0dp"
+                android:topLeftRadius="32.0dp"
+                android:topRightRadius="10.0dp" />
+            <size android:height="48.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:end="4.5dip"
+        android:gravity="fill_horizontal|center"
+        android:start="4.5dip">
+        <shape android:shape="rectangle">
+            <corners
+                android:bottomLeftRadius="6.0dp"
+                android:bottomRightRadius="28.0dp"
+                android:topLeftRadius="28.0dp"
+                android:topRightRadius="6.0dp" />
+            <size android:height="40.0dip" />
+            <solid android:color="?android:colorBackgroundFloating" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/ic_qs_brightness_auto_off.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/ic_qs_brightness_auto_off.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?android:attr/colorAccent" android:height="24.0dip" android:width="24.0dip" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M4.469 15.107V18c0 .828.671 1.5 1.5 1.5h2.893l2.046 2.046c.586.586 1.536.586   2.121 0l2.046-2.046h2.894c.828 0 1.5-.672 1.5-1.5v-2.893l2.046-2.046c.585-.586.585-1.536   0-2.122l-2.046-2.046V6c0-.828-.672-1.5-1.5-1.5h-2.894l-2.046-2.046c-.585-.586-1.535-.586-2.121   0L8.862 4.5H5.969c-.829 0-1.5.672-1.5 1.5v2.893l-2.046 2.046c-.586.586-.586 1.536 0 2.122l2.046 2.046   M 12 8.5 C 13.9329966244 8.5 15.5 10.0670033756 15.5 12 C 15.5 13.9329966244 13.9329966244 15.5 12 15.5   C 10.0670033756 15.5 8.5 13.9329966244 8.5 12 C 8.5   10.0670033756 10.0670033756 8.5 12 8.5 Z" android:strokeColor="#ffffffff" android:strokeWidth="1.5" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/ic_qs_brightness_auto_on.xml
+++ b/themes/brightness_slider/BrightnessSliderLeafyOutline/res/drawable/ic_qs_brightness_auto_on.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?android:attr/colorAccent" android:height="24.0dip" android:width="24.0dip" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M4.469 15.107V18c0 .828.671 1.5 1.5 1.5h2.893l2.046 2.046c.586.586 1.536.586   2.121 0l2.046-2.046h2.894c.828 0 1.5-.672 1.5-1.5v-2.893l2.046-2.046c.585-.586.585-1.536   0-2.122l-2.046-2.046V6c0-.828-.672-1.5-1.5-1.5h-2.894l-2.046-2.046c-.585-.586-1.535-.586-2.121   0L8.862 4.5H5.969c-.829 0-1.5.672-1.5 1.5v2.893l-2.046 2.046c-.586.586-.586 1.536 0 2.122l2.046 2.046   M9.195,15.25c0,0 1.792,-4.85 2.512,-6.796c0.045,-0.123 0.162,-0.204 0.293,-0.204c0.131,0 0.248,0.081   0.293,0.204c0.72,1.946 2.512,6.796 2.512,6.796m-4.512,-2.97l3.414,0" android:strokeColor="#ffffffff" android:strokeWidth="1.5" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderMinimalThumb/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderMinimalThumb/Android.bp
@@ -1,0 +1,6 @@
+//
+runtime_resource_overlay {
+    name: "BrightnessSliderMinimalThumbOverlay",
+    theme: "BrightnessSliderMinimalThumb",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderMinimalThumb/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderMinimalThumb/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.minimalthumb"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="MinimalThumb"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="16.0dip" />
+            <size android:height="32.0dip" />
+            <solid android:color="@*android:color/system_neutral2_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable-night/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable-night/brightness_progress_full_drawable.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="16.0dip" />
+            <size android:height="32.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:end="6.0dip"
+        android:gravity="end|center"
+        android:start="6.0dip">
+        <shape android:shape="rectangle">
+            <corners android:radius="10.0dip" />
+            <size
+                android:width="20.0dip"
+                android:height="20.0dip" />
+            <solid android:color="@*android:color/system_neutral2_800" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="16.0dip" />
+            <size android:height="32.0dip" />
+            <solid android:color="@*android:color/system_neutral2_10" />
+        </shape>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderMinimalThumb/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="16.0dip" />
+            <size android:height="32.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:end="6.0dip"
+        android:gravity="end|center"
+        android:start="6.0dip">
+        <shape android:shape="rectangle">
+            <corners android:radius="10.0dip" />
+            <size
+                android:width="20.0dip"
+                android:height="20.0dip" />
+            <solid android:color="@*android:color/system_neutral2_10" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderOutline/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderOutline/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "BrightnessSliderOutlineOverlay",
+    theme: "BrightnessSliderOutline",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderOutline/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.outline"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Outline"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 CorvusOS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+            android:paddingMode="stack" >
+    <item android:id="@android:id/background"
+        android:gravity="center_vertical|fill_horizontal">
+        <shape android:tint="?android:attr/colorAccent" android:shape="rectangle" android:alpha="0.5">
+            <size android:height="@dimen/rounded_slider_height" />
+            <corners android:radius="@dimen/rounded_slider_corner_radius" />
+            <solid android:color="@drawable/color_accent_alpha" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress"
+          android:gravity="center_vertical|fill_horizontal">
+            <com.android.systemui.util.RoundedCornerProgressDrawable
+                android:drawable="@drawable/brightness_progress_full_drawable"
+            />
+    </item>
+    <item
+        android:gravity="start|center"
+        android:drawable="@drawable/ic_brightness_low"
+        android:start="18.0dip" />
+    <item
+        android:gravity="end|center"
+        android:drawable="@drawable/ic_brightness_full"
+        android:end="18.0dip" />
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 CorvusOS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:priv-android="http://schemas.android.com/apk/prv/res/android"
+    android:autoMirrored="true">
+    <item android:id="@null"
+        android:height="@dimen/rounded_slider_height">
+        <shape>
+            <size android:height="@dimen/rounded_slider_height" />
+            <stroke android:width="2.5dp" android:color="?android:attr/colorAccent" />
+            <solid android:color="@drawable/color_accent_alpha" />
+            <corners android:radius="@dimen/rounded_slider_corner_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/color_accent_alpha.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/color_accent_alpha.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.5" android:color="?android:attr/colorAccent" />
+</selector>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_brightness_full.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_brightness_full.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:androidprv="http://schemas.android.com/apk/prv/res/android"
+    android:height="18dp"
+    android:width="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="?android:colorAccent"
+        android:pathData="M11.1 5V1h1.8v4h-1.8zM12 6.1c-3.258 0-5.9 2.642-5.9 5.9 0 3.258 2.642 5.9 5.9 5.9 3.259 0 5.9-2.641 5.9-5.9 0-3.258-2.641-5.9-5.9-5.9zm7.142-2.514l-2.828 2.828 1.273 1.272 2.828-2.828-1.273-1.272zM19 11.1h4v1.8h-4v-1.8zm1.415 8.042l-2.828-2.828-1.273 1.272 2.828 2.828 1.273-1.272zM12.9 19v4h-1.8v-4h1.8zm-8.041 1.414l2.827-2.828-1.272-1.272-2.828 2.828 1.273 1.272zM5 12.9H1v-1.8h4v1.8zM3.586 4.858l2.828 2.828 1.272-1.272L4.86 3.586 3.586 4.858z"
+        android:strokeWidth="1.0"/>
+</vector>
+

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_brightness_low.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_brightness_low.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:androidprv="http://schemas.android.com/apk/prv/res/android"
+    android:height="18dp"
+    android:width="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="?android:colorAccent"
+        android:pathData="M11.25 3h1.5v2h-1.5V3zm-5 9c0 3.176 2.574 5.75 5.75 5.75s5.75-2.574 5.75-5.75S15.176 6.25 12 6.25 6.25 8.824 6.25 12zm10 0c0 2.347-1.903 4.25-4.25 4.25S7.75 14.347 7.75 12 9.653 7.75 12 7.75s4.25 1.903 4.25 4.25zm-5 9v-2h1.5v2h-1.5zM3 11.25v1.5h2v-1.5H3zm16 1.5h2v-1.5h-2v1.5zM6.17 18.89l-1.06-1.06 1.41-1.41 1.06 1.06-1.41 1.41zm0-13.78L5.11 6.17l1.41 1.41 1.06-1.06-1.41-1.41zm11.66 0l1.06 1.06-1.41 1.41-1.06-1.06 1.41-1.41zm0 13.78l1.06-1.06-1.41-1.41-1.06 1.06 1.41 1.41z"
+        android:fillType="evenOdd"
+        android:strokeWidth="1.0"/>
+</vector>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_qs_brightness_auto_off.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_qs_brightness_auto_off.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?android:attr/colorAccent" android:height="24.0dip" android:width="24.0dip" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M4.469 15.107V18c0 .828.671 1.5 1.5 1.5h2.893l2.046 2.046c.586.586 1.536.586   2.121 0l2.046-2.046h2.894c.828 0 1.5-.672 1.5-1.5v-2.893l2.046-2.046c.585-.586.585-1.536   0-2.122l-2.046-2.046V6c0-.828-.672-1.5-1.5-1.5h-2.894l-2.046-2.046c-.585-.586-1.535-.586-2.121   0L8.862 4.5H5.969c-.829 0-1.5.672-1.5 1.5v2.893l-2.046 2.046c-.586.586-.586 1.536 0 2.122l2.046 2.046   M 12 8.5 C 13.9329966244 8.5 15.5 10.0670033756 15.5 12 C 15.5 13.9329966244 13.9329966244 15.5 12 15.5   C 10.0670033756 15.5 8.5 13.9329966244 8.5 12 C 8.5   10.0670033756 10.0670033756 8.5 12 8.5 Z" android:strokeColor="#ffffffff" android:strokeWidth="1.5" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_qs_brightness_auto_on.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/drawable/ic_qs_brightness_auto_on.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?android:attr/colorAccent" android:height="24.0dip" android:width="24.0dip" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M4.469 15.107V18c0 .828.671 1.5 1.5 1.5h2.893l2.046 2.046c.586.586 1.536.586   2.121 0l2.046-2.046h2.894c.828 0 1.5-.672 1.5-1.5v-2.893l2.046-2.046c.585-.586.585-1.536   0-2.122l-2.046-2.046V6c0-.828-.672-1.5-1.5-1.5h-2.894l-2.046-2.046c-.585-.586-1.535-.586-2.121   0L8.862 4.5H5.969c-.829 0-1.5.672-1.5 1.5v2.893l-2.046 2.046c-.586.586-.586 1.536 0 2.122l2.046 2.046   M9.195,15.25c0,0 1.792,-4.85 2.512,-6.796c0.045,-0.123 0.162,-0.204 0.293,-0.204c0.131,0 0.248,0.081   0.293,0.204c0.72,1.946 2.512,6.796 2.512,6.796m-4.512,-2.97l3.414,0" android:strokeColor="#ffffffff" android:strokeWidth="1.5" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderOutline/res/values/dimens.xml
+++ b/themes/brightness_slider/BrightnessSliderOutline/res/values/dimens.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 CorvusOS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+  <resources>
+    <dimen name="rounded_slider_corner_radius">24.0dip</dimen>
+    <dimen name="rounded_slider_height">48.0dip</dimen>
+    <dimen name="brightness_mirror_height">48.0dip</dimen>
+    <dimen name="rounded_slider_background_rounded_corner">32.0dip</dimen>
+</resources>

--- a/themes/brightness_slider/BrightnessSliderRoundedClip/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderRoundedClip/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "BrightnessSliderRoundedClipOverlay",
+    theme: "BrightnessSliderRoundedClip",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderRoundedClip/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderRoundedClip/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.roundedclip"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="RoundedClip"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderRoundedClip/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderRoundedClip/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="24.0dip" />
+            <size android:height="48.0dip" />
+            <solid android:color="@*android:color/system_neutral2_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <clip
+            android:clipOrientation="horizontal"
+            android:gravity="left">
+            <selector>
+                <item>
+                    <shape android:shape="rectangle">
+                        <corners android:radius="24.0dip" />
+                        <size android:height="48.0dip" />
+                        <solid android:color="?android:colorAccent" />
+                    </shape>
+                </item>
+            </selector>
+        </clip>
+    </item>
+</layer-list>
+

--- a/themes/brightness_slider/BrightnessSliderRoundedClip/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderRoundedClip/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle">
+            <corners android:radius="24.0dip" />
+            <size android:height="48.0dip" />
+            <solid android:color="@*android:color/system_neutral2_10" />
+        </shape>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <clip
+            android:clipOrientation="horizontal"
+            android:gravity="left">
+            <selector>
+                <item>
+                    <shape android:shape="rectangle">
+                        <corners android:radius="24.0dip" />
+                        <size android:height="48.0dip" />
+                        <solid android:color="?android:colorAccent" />
+                    </shape>
+                </item>
+            </selector>
+        </clip>
+    </item>
+</layer-list>
+

--- a/themes/brightness_slider/BrightnessSliderShaded/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderShaded/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "BrightnessSliderShadedOverlay",
+    theme: "BrightnessSliderShaded",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderShaded/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.shaded"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Shaded"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderShaded/res/drawable-night/brightness_bg.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/res/drawable-night/brightness_bg.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center">
+        <shape android:tintMode="multiply">
+            <corners android:radius="24.0dip" />
+            <solid android:color="?android:colorAccent" />
+            <size android:height="48.0dip" android:width="48.0dip" />
+        </shape>
+    </item>
+    <item android:gravity="fill_horizontal|center" android:start="4.5dip" android:end="4.5dip">
+        <shape android:tintMode="multiply">
+            <corners android:radius="20.0dip" />
+            <gradient android:startColor="#40000000" android:endColor="#00000000" android:angle="0.0" android:centerColor="#00000000" />
+            <size android:height="40.0dip" android:width="40.0dip" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderShaded/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <layer-list>
+            <item android:gravity="fill_horizontal|center">
+                <shape android:shape="rectangle">
+                    <corners android:radius="24.0dip" />
+                    <size android:height="48.0dip" />
+                    <solid android:color="@*android:color/system_neutral2_800" />
+                </shape>
+            </item>
+            <item
+                android:gravity="fill_horizontal|center"
+                android:start="4.5dip"
+                android:end="4.5dip">
+                <shape android:shape="rectangle">
+                    <corners android:radius="20.0dip" />
+                    <size android:height="40.0dip" />
+                    <gradient
+                        android:centerColor="#00000000"
+                        android:endColor="#00000000"
+                        android:startColor="#1A000000" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderShaded/res/drawable-night/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/res/drawable-night/brightness_progress_full_drawable.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle" android:tintMode="multiply">
+            <corners android:radius="24.0dip" />
+            <size android:height="48.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:gravity="fill_horizontal|center"
+        android:start="4.5dip"
+        android:end="4.5dip">
+        <shape android:shape="rectangle" android:tintMode="multiply">
+            <corners android:radius="20.0dip" />
+            <size android:height="40.0dip" />
+            <gradient
+                android:angle="270.0"
+                android:centerColor="#00000000"
+                android:endColor="#00000000"
+                android:startColor="#40000000" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderShaded/res/drawable/brightness_bg.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/res/drawable/brightness_bg.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="fill_horizontal|center">
+        <shape android:tintMode="src_atop">
+            <corners android:radius="24.0dip" />
+            <solid android:color="?android:colorAccent" />
+            <size android:height="48.0dip" android:width="48.0dip" />
+        </shape>
+    </item>
+    <item android:gravity="fill_horizontal|center" android:start="4.5dip" android:end="4.5dip">
+        <shape android:tintMode="multiply">
+            <corners android:radius="20.0dip" />
+            <gradient android:startColor="#40000000" android:endColor="#00000000" android:angle="0.0" android:centerColor="#00000000" />
+            <size android:height="40.0dip" android:width="40.0dip" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderShaded/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@*android:id/background"
+        android:gravity="fill_horizontal|center">
+        <layer-list>
+            <item android:gravity="fill_horizontal|center">
+                <shape android:shape="rectangle">
+                    <corners android:radius="24.0dip" />
+                    <size android:height="48.0dip" />
+                    <solid android:color="@*android:color/system_neutral2_0" />
+                </shape>
+            </item>
+            <item
+                android:gravity="fill_horizontal|center"
+                android:start="4.5dip"
+                android:end="4.5dip">
+                <shape android:shape="rectangle">
+                    <corners android:radius="20.0dip" />
+                    <size android:height="40.0dip" />
+                    <gradient
+                        android:centerColor="#00000000"
+                        android:endColor="#00000000"
+                        android:startColor="#1A000000" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+    <item
+        android:id="@*android:id/progress"
+        android:gravity="fill_horizontal|center">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderShaded/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderShaded/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@null"
+        android:gravity="fill_horizontal|center">
+        <shape android:shape="rectangle" android:tintMode="src_atop">
+            <corners android:radius="24.0dip" />
+            <size android:height="48.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item
+        android:gravity="fill_horizontal|center"
+        android:start="4.5dip"
+        android:end="4.5dip">
+        <shape android:shape="rectangle" android:tintMode="multiply">
+            <corners android:radius="20.0dip" />
+            <size android:height="40.0dip" />
+            <gradient
+                android:angle="270.0"
+                android:centerColor="#00000000"
+                android:endColor="#00000000"
+                android:startColor="#40000000" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderThin/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderThin/Android.bp
@@ -1,0 +1,10 @@
+//
+// Copyright (C) 2023 The Leaf Project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+runtime_resource_overlay {
+    name: "BrightnessSliderThinOverlay",
+    theme: "BrightnessSliderThin",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderThin/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.thin"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Thin"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderThin/res/drawable-night/brightness_mirror_background.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/res/drawable-night/brightness_mirror_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/system_neutral1_900" />
+    <corners android:radius="14.0dip" />
+</shape>

--- a/themes/brightness_slider/BrightnessSliderThin/res/drawable-night/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/res/drawable-night/brightness_progress_drawable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background" android:gravity="center_vertical|fill_horizontal">
+        <shape>
+            <size android:height="4.0dip" />
+            <corners android:radius="2.0dip" />
+            <solid android:color="@android:color/system_neutral1_800" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress" android:gravity="center_vertical|fill_horizontal">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable_thin" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderThin/res/drawable/brightness_mirror_background.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/res/drawable/brightness_mirror_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/system_neutral1_50" />
+    <corners android:radius="14.0dip" />
+</shape>

--- a/themes/brightness_slider/BrightnessSliderThin/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background" android:gravity="center_vertical|fill_horizontal">
+        <shape>
+            <size android:height="4.0dip" />
+            <corners android:radius="2.0dip" />
+            <solid android:color="@android:color/system_neutral1_10" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress" android:gravity="center_vertical|fill_horizontal">
+        <com.android.systemui.util.RoundedCornerProgressDrawable android:drawable="@drawable/brightness_progress_full_drawable_thin" />
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderThin/res/drawable/brightness_progress_full_drawable_thin.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/res/drawable/brightness_progress_full_drawable_thin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="center_vertical|fill_horizontal">
+        <shape>
+            <size android:height="4.0dip" />
+            <corners android:radius="2.0dip" />
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+    <item android:gravity="end|center" android:drawable="@drawable/ic_brightness_thumb" />
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderThin/res/drawable/ic_brightness_thumb.xml
+++ b/themes/brightness_slider/BrightnessSliderThin/res/drawable/ic_brightness_thumb.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<vector android:tint="?android:colorAccent" android:height="14.0dip" android:width="14.0dip" android:viewportWidth="42.0" android:viewportHeight="42.0"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#ffffffff" android:pathData="M 21 0 C 32.5979797464 0 42 9.40202025355 42 21 C 42 32.5979797464 32.5979797464 42 21 42 C 9.40202025355 42 0 32.5979797464 0 21 C 0 9.40202025355 9.40202025355 0 21 0 Z" android:strokeWidth="1.0" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/Android.bp
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "BrightnessSliderTranslucentOverlay",
+    theme: "BrightnessSliderTranslucent",
+    product_specific: true,
+}

--- a/themes/brightness_slider/BrightnessSliderTranslucent/AndroidManifest.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 The LeafOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.systemui.brightness_slider.translucent"
+    android:allowBackup="false"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <overlay
+        android:priority="1"
+        android:targetPackage="com.android.systemui"
+        android:category="android.theme.customization.brightness_slider" />
+
+    <application
+        android:label="Translucent"
+        android:hasCode="false"/>
+</manifest>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/brightness_progress_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/brightness_progress_drawable.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 CorvusOS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+            android:paddingMode="stack" >
+    <item android:id="@android:id/background"
+        android:gravity="center_vertical|fill_horizontal">
+        <shape android:shape="rectangle">
+            <size android:height="@dimen/rounded_slider_height" />
+            <corners android:radius="@dimen/rounded_slider_corner_radius" />
+            <solid android:color="@color/qs_translucent_brightness_bg" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress"
+          android:gravity="center|fill_horizontal">
+            <com.android.systemui.util.RoundedCornerProgressDrawable
+                android:drawable="@drawable/brightness_progress_full_drawable"
+            />
+    </item>
+    <item
+        android:gravity="start|center"
+        android:drawable="@drawable/ic_brightness_low"
+        android:start="18.0dip" />
+    <item
+        android:gravity="end|center"
+        android:drawable="@drawable/ic_brightness_full"
+        android:end="18.0dip" />
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/brightness_progress_full_drawable.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/brightness_progress_full_drawable.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:priv-android="http://schemas.android.com/apk/prv/res/android"
+    android:autoMirrored="true">
+    <item android:id="@+id/slider_foreground"
+        android:height="@dimen/rounded_slider_height">
+        <shape>
+            <size android:height="@dimen/rounded_slider_height" />
+            <solid android:color="@drawable/color_accent_alpha" />
+            <corners android:radius="@dimen/rounded_slider_corner_radius" />
+        </shape>
+    </item>
+</layer-list>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/color_accent_alpha.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/color_accent_alpha.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.2" android:color="?android:attr/colorAccent" />
+</selector>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_brightness_full.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_brightness_full.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:androidprv="http://schemas.android.com/apk/prv/res/android"
+    android:height="18dp"
+    android:width="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="?android:colorAccent"
+        android:pathData="M11.1 5V1h1.8v4h-1.8zM12 6.1c-3.258 0-5.9 2.642-5.9 5.9 0 3.258 2.642 5.9 5.9 5.9 3.259 0 5.9-2.641 5.9-5.9 0-3.258-2.641-5.9-5.9-5.9zm7.142-2.514l-2.828 2.828 1.273 1.272 2.828-2.828-1.273-1.272zM19 11.1h4v1.8h-4v-1.8zm1.415 8.042l-2.828-2.828-1.273 1.272 2.828 2.828 1.273-1.272zM12.9 19v4h-1.8v-4h1.8zm-8.041 1.414l2.827-2.828-1.272-1.272-2.828 2.828 1.273 1.272zM5 12.9H1v-1.8h4v1.8zM3.586 4.858l2.828 2.828 1.272-1.272L4.86 3.586 3.586 4.858z"
+        android:strokeWidth="1.0"/>
+</vector>
+

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_brightness_low.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_brightness_low.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:androidprv="http://schemas.android.com/apk/prv/res/android"
+    android:height="18dp"
+    android:width="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="?android:colorAccent"
+        android:pathData="M11.25 3h1.5v2h-1.5V3zm-5 9c0 3.176 2.574 5.75 5.75 5.75s5.75-2.574 5.75-5.75S15.176 6.25 12 6.25 6.25 8.824 6.25 12zm10 0c0 2.347-1.903 4.25-4.25 4.25S7.75 14.347 7.75 12 9.653 7.75 12 7.75s4.25 1.903 4.25 4.25zm-5 9v-2h1.5v2h-1.5zM3 11.25v1.5h2v-1.5H3zm16 1.5h2v-1.5h-2v1.5zM6.17 18.89l-1.06-1.06 1.41-1.41 1.06 1.06-1.41 1.41zm0-13.78L5.11 6.17l1.41 1.41 1.06-1.06-1.41-1.41zm11.66 0l1.06 1.06-1.41 1.41-1.06-1.06 1.41-1.41zm0 13.78l1.06-1.06-1.41-1.41-1.06 1.06 1.41 1.41z"
+        android:fillType="evenOdd"
+        android:strokeWidth="1.0"/>
+</vector>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_qs_brightness_auto_off.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_qs_brightness_auto_off.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?android:attr/colorAccent" android:height="24.0dip" android:width="24.0dip" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M4.469 15.107V18c0 .828.671 1.5 1.5 1.5h2.893l2.046 2.046c.586.586 1.536.586   2.121 0l2.046-2.046h2.894c.828 0 1.5-.672 1.5-1.5v-2.893l2.046-2.046c.585-.586.585-1.536   0-2.122l-2.046-2.046V6c0-.828-.672-1.5-1.5-1.5h-2.894l-2.046-2.046c-.585-.586-1.535-.586-2.121   0L8.862 4.5H5.969c-.829 0-1.5.672-1.5 1.5v2.893l-2.046 2.046c-.586.586-.586 1.536 0 2.122l2.046 2.046   M 12 8.5 C 13.9329966244 8.5 15.5 10.0670033756 15.5 12 C 15.5 13.9329966244 13.9329966244 15.5 12 15.5   C 10.0670033756 15.5 8.5 13.9329966244 8.5 12 C 8.5   10.0670033756 10.0670033756 8.5 12 8.5 Z" android:strokeColor="#ffffffff" android:strokeWidth="1.5" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_qs_brightness_auto_on.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/drawable/ic_qs_brightness_auto_on.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:tint="?android:attr/colorAccent" android:height="24.0dip" android:width="24.0dip" android:viewportWidth="24.0" android:viewportHeight="24.0"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M4.469 15.107V18c0 .828.671 1.5 1.5 1.5h2.893l2.046 2.046c.586.586 1.536.586   2.121 0l2.046-2.046h2.894c.828 0 1.5-.672 1.5-1.5v-2.893l2.046-2.046c.585-.586.585-1.536   0-2.122l-2.046-2.046V6c0-.828-.672-1.5-1.5-1.5h-2.894l-2.046-2.046c-.585-.586-1.535-.586-2.121   0L8.862 4.5H5.969c-.829 0-1.5.672-1.5 1.5v2.893l-2.046 2.046c-.586.586-.586 1.536 0 2.122l2.046 2.046   M9.195,15.25c0,0 1.792,-4.85 2.512,-6.796c0.045,-0.123 0.162,-0.204 0.293,-0.204c0.131,0 0.248,0.081   0.293,0.204c0.72,1.946 2.512,6.796 2.512,6.796m-4.512,-2.97l3.414,0" android:strokeColor="#ffffffff" android:strokeWidth="1.5" android:strokeLineCap="round" android:strokeLineJoin="round" />
+</vector>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/values-night/colors.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/values-night/colors.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 crDroid Android Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+
+<resources>
+
+    <color name="qs_translucent_brightness_bg">#0FFFFFFF</color>
+</resources>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/values/colors.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/values/colors.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2023 crDroid Android Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+
+<resources>
+
+    <color name="qs_translucent_brightness_bg">#33FFFFFF</color>
+</resources>

--- a/themes/brightness_slider/BrightnessSliderTranslucent/res/values/dimens.xml
+++ b/themes/brightness_slider/BrightnessSliderTranslucent/res/values/dimens.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 CorvusOS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+  <resources>
+    <dimen name="rounded_slider_corner_radius">24.0dip</dimen>
+    <dimen name="rounded_slider_height">48.0dip</dimen>
+    <dimen name="brightness_mirror_height">48.0dip</dimen>
+    <dimen name="rounded_slider_background_rounded_corner">32.0dip</dimen>
+</resources>


### PR DESCRIPTION
Squashed in:

Author: Pzqqt <821026875@qq.com>
Date:   Sat Jun 10 14:12:28 2023 +0800

    addons: brightness_slider: Fixup

    - Replace all `harmful_*` properties that define corner radius with sensible values.
    - Remove useless resources.

    Memo:
      - `bg_qs_brightness_auto_on` and `bg_qs_brightness_auto_off`: The background of the auto-brightness button. (unused)
      - `brightness_mirror_background`: The background that appears when dragging the brightness bar. - `brightness_progress_drawable` and `brightness_progress_full_drawable`: The style of the brightness bar. - `ic_qs_brightness_auto_on` and `ic_qs_brightness_auto_off`: The icon of the auto-brightness button.

Author: rdx420 <padraramesh420@gmail.com>
Date:   Sat May 27 23:12:57 2023 +0200

    addons: Add more brightness slider styles

    Credit - https://github.com/Mahmud0808/Iconify

Author: Pzqqt <821026875@qq.com>
Date:   Mon Jun 5 13:49:27 2023 +0800

    themes: overlays: Some tweaks to BrightnessSliderGradient

    And rename "Gradient" to "GradientRoundedBar"

Author: Pzqqt <821026875@qq.com>
Date:   Sat Jun 3 13:39:45 2023 +0800

    themes: overlays: Add gradient brightness slider

    Taken from [Iconify](https://github.com/Mahmud0808/Iconify)

Author: Pranav Vashi <neobuddy89@gmail.com>
Date:   Sat Jun 3 01:05:37 2023 +0530

    addons: Add category for brightness slider themes

    Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>

Author: Ghosuto <clash.raja10@gmail.com>
Date:   Sat May 6 05:53:15 2023 +0000

    themes: overlays: add acun and bang brightness slider [3/3]

    Signed-off-by: RakeshBatra <raakesh.batra@rediffmail.com>




Change-Id: I5ec57a37727a1d543bc102b84f1d8cfc2d85af3e